### PR TITLE
fix: 统一Pagination文档页面的查看代码和复制代码按钮的格式

### DIFF
--- a/src/pages/packages/pagination.tsx
+++ b/src/pages/packages/pagination.tsx
@@ -21,18 +21,12 @@ export default function IconPage() {
         subtitle="使用方法"
         subnotes=""
         demo={<Demo1 />}
-        showCopy={false}
-        showView={false}
-        showCode
         path="pagination/demo1"
       />
       <InstanceView
         subtitle="其他属性和方法"
         subnotes=""
         demo={<Demo2 />}
-        showCopy={false}
-        showView={false}
-        showCode
         path="pagination/demo2"
       />
       <Api />


### PR DESCRIPTION
统一Pagination文档页面的查看代码和复制代码按钮的格式

右侧下拉框样式，目前用的原生select组件，等我们的Select组件合入了，再来修改吧